### PR TITLE
Test enhancement

### DIFF
--- a/tests/ApiDefinitionTest.php
+++ b/tests/ApiDefinitionTest.php
@@ -17,6 +17,7 @@ use Raml\Types\StringType;
 use Raml\Types\TypeValidationError;
 use Raml\Types\UnionType;
 use Raml\ValidatorInterface;
+use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
 class ApiDefinitionTest extends TestCase
@@ -85,8 +86,8 @@ class ApiDefinitionTest extends TestCase
         $this->assertEquals($routeFormatter, $routes);
 
         $this->assertCount(4, $routeFormatter->getRoutes());
-        $this->assertInstanceOf('\Symfony\Component\Routing\RouteCollection', $routeFormatter->getRoutes());
-        $this->assertInstanceOf('\Symfony\Component\Routing\Route', $routeFormatter->getRoutes()->get('GET /songs/'));
+        $this->assertInstanceOf(RouteCollection::class, $routeFormatter->getRoutes());
+        $this->assertInstanceOf(Route::class, $routeFormatter->getRoutes()->get('GET /songs/'));
         $this->assertEquals(['http'], $routeFormatter->getRoutes()->get('GET /songs/')->getSchemes());
     }
 

--- a/tests/XmlSchemaTest.php
+++ b/tests/XmlSchemaTest.php
@@ -66,7 +66,7 @@ RAML;
      */
     public function shouldReturnXmlSchemeDefinition()
     {
-        $this->assertInstanceOf('Raml\Schema\Definition\XmlSchemaDefinition', $this->getSchema());
+        $this->assertInstanceOf(XmlSchemaDefinition::class, $this->getSchema());
     }
 
     /**


### PR DESCRIPTION
# Changed log
- Using the `::class` magic approach for all classes because of consistency.
- The Travis CI build is failed in `php-7.3` because the `security.sensiolabs.org` host cannot be resolved at this moment.