### PR TITLE
Fix object validation error when input is not an array

### DIFF
--- a/src/Types/ObjectType.php
+++ b/src/Types/ObjectType.php
@@ -111,7 +111,7 @@ class ObjectType extends Type
      */
     public function discriminate($value)
     {
-        if (isset($value[$this->getDiscriminator()])) {
+        if (\is_array($value) && isset($value[$this->getDiscriminator()])) {
             if ($this->getDiscriminatorValue() !== null) {
                 return $this->getDiscriminatorValue() === $value[$this->getDiscriminator()];
             }

--- a/tests/Types/ObjectTypeTest.php
+++ b/tests/Types/ObjectTypeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Raml\Tests\Types;
+
+use PHPUnit\Framework\TestCase;
+use Raml\ApiDefinition;
+use Raml\Parser;
+use Raml\Types\TypeValidationError;
+
+class ObjectTypeTest extends TestCase
+{
+    /**
+     * @var ApiDefinition
+     */
+    private $apiDefinition;
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->apiDefinition = (new Parser())->parse(__DIR__ . '/../fixture/object_types.raml');
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCorrectlyValidateCorrectType()
+    {
+        $resource = $this->apiDefinition->getResourceByUri('/actors/1');
+        $method = $resource->getMethod('get');
+        $response = $method->getResponse(200);
+        $body = $response->getBodyByType('application/json');
+        $type = $body->getType();
+
+        $type->validate([
+            'fistName' => 'Jackie',
+            'lastName' => 'Сhan',
+        ]);
+
+        $this->assertTrue($type->isValid());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotCorrectlyValidateObjectType()
+    {
+        $resource = $this->apiDefinition->getResourceByUri('/actors/1');
+        $method = $resource->getMethod('get');
+        $response = $method->getResponse(200);
+        $body = $response->getBodyByType('application/json');
+        $type = $body->getType();
+
+        $type->validate('Jackie Сhan');
+
+        $this->assertFalse($type->isValid());
+        $this->assertCount(1, $type->getErrors());
+        $this->assertInstanceOf(TypeValidationError::class, $type->getErrors()[0]);
+    }
+}

--- a/tests/fixture/object_types.raml
+++ b/tests/fixture/object_types.raml
@@ -1,0 +1,23 @@
+#%RAML 1.0
+
+title: List of actors API
+baseUri: http://example.api.com/{version}
+version: v1
+mediaType: application/json
+
+/actors/{id}:
+  get:
+    responses:
+      200:
+        body:
+          application/json:
+            type: Actor
+types:
+  Actor:
+    properties:
+      fistName:
+        type: string
+        required: true
+      lastName:
+        type: string
+        required: true


### PR DESCRIPTION
I've been facing object validation problem, when input value is string. It happens because discriminate method of ObjectType tried to access to string value as array. In my PR I fixed it. Hope to fast review and approve or constructive comments for this situation.