### PR TITLE
Support optional resource type methods declaration

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -796,6 +796,7 @@ class Parser
                     $newName = (isset($value['displayName'])) ? $value['displayName'] : \substr($key, 1);
                 }
                 $newValue = $this->replaceTypes($value, $types, $path, $newName, $key);
+                $newValue = $this->applyOptionalResourceTypeMethod($key, $newArray, $newValue, $parentKey);
 
                 $newArray[$key] = isset($newArray[$key]) && \is_array($newArray[$key]) ? \array_replace_recursive($newArray[$key], $newValue) : $newValue;
             }
@@ -812,6 +813,29 @@ class Parser
     private function applyVariables(array $values, array $trait)
     {
         return TraitParserHelper::applyVariables($values, $trait);
+    }
+
+    /**
+     * Apply optional HTTP method from resource type
+     *
+     * @param string|mixed $key
+     * @param array $source
+     * @param string|array $value
+     * @param string|null $parentKey
+     * @return string|array
+     */
+    private function applyOptionalResourceTypeMethod($key, $source, $value, $parentKey = null)
+    {
+        $optionalKey = $key . '?';
+        if (
+            \strpos($parentKey, '/') === 0
+            && \in_array(\strtoupper($key), Method::$validMethods, true)
+            && isset($source[$optionalKey])
+        ) {
+            $value = \is_array($value) ? \array_replace_recursive($source[$optionalKey], $value) : $source[$optionalKey];
+        }
+
+        return $value;
     }
 
     public function getIncludedFiles()

--- a/src/Resource.php
+++ b/src/Resource.php
@@ -186,7 +186,7 @@ class Resource implements ArrayInstantiationInterface
                 $resource->addMethod(
                     Method::createFromArray(
                         $key,
-                        $value,
+                        \is_array($value) ? $value : [],
                         $apiDefinition
                     )
                 );

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -1226,4 +1226,32 @@ RAML;
             $headers
         );
     }
+
+    /**
+     * @test
+     */
+    public function shouldParseOptionalMethods()
+    {
+        $apiDefinition = $this->parser->parse(__DIR__ . '/fixture/raml-1.0/optionalResourceTypeMethods.raml');
+
+        $resource = $apiDefinition->getResourceByUri('/servers');
+        $method = $resource->getMethod('post');
+        $headers = $method->getHeaders();
+
+        $this->assertSame('Some info about post method.', $method->getDescription());
+        $this->assertArrayHasKey('X-Chargeback', $headers);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotHaveOptionalMethod()
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Method not found');
+
+        $apiDefinition = $this->parser->parse(__DIR__ . '/fixture/raml-1.0/optionalResourceTypeMethods.raml');
+        $resource = $apiDefinition->getResourceByUri('/queues');
+        $resource->getMethod('post');
+    }
 }

--- a/tests/fixture/raml-1.0/optionalResourceTypeMethods.raml
+++ b/tests/fixture/raml-1.0/optionalResourceTypeMethods.raml
@@ -1,0 +1,20 @@
+#%RAML 1.0
+title: Example of Optional Properties
+resourceTypes:
+  corpResource:
+    post?:
+      description: Some info about <<TextAboutPost>>.
+      headers:
+        X-Chargeback:
+          required: true
+/servers:
+  type:
+    corpResource:
+      TextAboutPost: post method # post defined which will force to define the TextAboutPost parameter
+  get:
+  post: # will require the X-Chargeback header
+/queues:
+  type: corpResource
+  get:
+  # will not have a post method defined which means the TextAboutPost parameter is
+  # not required; same for the X-Chargeback header


### PR DESCRIPTION
Allows to use [optional HTTP methods](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#declaring-http-methods-as-optional) in resource types.