### PR TITLE
Drop support for EOL PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,16 +38,17 @@ before_install:
   - mkdir -p build/logs
 
 install:
-  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
-      composer remove friendsofphp/php-cs-fixer phpstan/phpstan --dev;
-    fi
   - if [ "$DEPENDENCIES" = "beta" ]; then
       composer config minimum-stability beta;
-      composer update -n --prefer-dist;
+      composer update -n --no-dev --prefer-dist;
     elif [ "$DEPENDENCIES" = "low" ]; then
-      composer update -n --prefer-dist --prefer-lowest;
+      composer update -n --no-dev --prefer-dist --prefer-lowest;
     else
-      composer update -n --prefer-dist;
+      composer update -n --no-dev --prefer-dist;
+    fi;
+  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
+      echo "Install dev dependencies";
+      composer update -n --dev
     fi;
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,6 @@ install:
 
 script:
   - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
-      echo "File validation is skipped for older PHP versions";
-    else
-      composer validate-files;
-    fi;
-  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
       echo "Static analysis is skipped for older PHP versions";
     else
       composer run-static-analysis;

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ install:
     fi;
   - if [ "$(phpenv version-name)" = "$LATEST_PHP_VERSION" ]; then
       echo "Install dev dependencies";
-      composer update -n --dev
+      composer update -n --dev;
     fi;
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,12 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
   - nightly
 
 env:
   global:
-    - LATEST_PHP_VERSION="7.3"
+    - LATEST_PHP_VERSION="7.4"
   matrix:
     - DEPENDENCIES="beta"
     - DEPENDENCIES="low"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
   - 7.3
   - 7.4
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
     else
       composer update -n --no-dev --prefer-dist;
     fi;
-  - if [ "$(phpenv version-name)" != "$LATEST_PHP_VERSION" ]; then
+  - if [ "$(phpenv version-name)" = "$LATEST_PHP_VERSION" ]; then
       echo "Install dev dependencies";
       composer update -n --dev
     fi;

--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ There are two Route Formatters included in the package:
 
 ### Contributing
 ```bash
-composer validate-files
 composer run-static-analysis
 composer check-code-style
 composer run-tests

--- a/composer.json
+++ b/composer.json
@@ -52,38 +52,36 @@
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "*",
-    "jakub-onderka/php-parallel-lint": "^1.0",
     "php-coveralls/php-coveralls": "^2.1",
-    "phpstan/phpstan": "^0.11",
-    "phpunit/phpunit": "^5.7",
-    "sensiolabs/security-checker": "^5.0"
+    "phpstan/phpstan": "^0.12",
+    "phpstan/phpstan-phpunit": "^0.12.16",
+    "phpunit/phpunit": "^9.0",
+    "sensiolabs/security-checker": "^5.0",
+    "slam/phpstan-extensions": "^5.0"
   },
 
   "scripts": {
     "check-code-style": [
-      "php-cs-fixer fix --config='.php_cs' --no-interaction --diff -v --dry-run"
+      "php-cs-fixer fix --config='./tools/php-cs-fixer/config.php' --no-interaction --diff -v --dry-run"
     ],
     "check-security": [
       "security-checker security:check"
     ],
     "fix-code-style": [
-      "php-cs-fixer fix --config='.php_cs' --no-interaction --diff -v"
+      "php-cs-fixer fix --config='./tools/php-cs-fixer/config.php' --no-interaction --diff -v"
+    ],
+    "generate-phpstan-baselines": [
+      "phpstan analyse src/ --generate-baseline='./tools/phpstan/baseline/src.neon' --configuration='./tools/phpstan/config.neon' --ansi",
+      "phpstan analyse tests/ --generate-baseline='./tools/phpstan/baseline/tests.neon' --configuration='./tools/phpstan/config.neon' --ansi"
     ],
     "run-static-analysis": [
-      "phpstan analyse --level=1 src/"
-    ],
-    "run-static-analysis-including-tests": [
-      "@run-static-analysis",
-      "phpstan analyse --level=3 tests/"
+      "phpstan analyse src/ tests/ --configuration='./tools/phpstan/config.neon' --ansi --no-progress"
     ],
     "run-tests": [
-      "phpunit"
+      "phpunit --configuration='./tools/phpunit/config.xml'"
     ],
     "run-tests-with-clover": [
-      "phpunit --coverage-clover build/logs/clover.xml"
-    ],
-    "validate-files": [
-      "parallel-lint --exclude vendor --exclude bin ."
+      "phpunit --coverage-clover='./build/logs/clover.xml'"
     ]
   },
 

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
       "phpunit --configuration='./tools/phpunit/config.xml'"
     ],
     "run-tests-with-clover": [
-      "phpunit --coverage-clover='./build/logs/clover.xml'"
+      "phpunit --configuration='./tools/phpunit/config.xml' --coverage-clover='./build/logs/clover.xml'"
     ]
   },
 

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
   },
 
   "require": {
-    "php": "^5.6|^7.0",
+    "php": "^7.3",
     "ext-dom": "*",
     "ext-json": "*",
     "ext-pcre": "*",

--- a/src/NamedParameter.php
+++ b/src/NamedParameter.php
@@ -278,8 +278,6 @@ class NamedParameter implements ArrayInstantiationInterface
      * A default value used by the server if not provided
      *
      * @see http://raml.org/spec.html#default
-     *
-     * @var mixed
      */
     private $default;
 
@@ -654,11 +652,11 @@ class NamedParameter implements ArrayInstantiationInterface
      *
      * @param int $position
      *
-     * @return string
+     * @return string|null
      */
     public function getExample($position = 0)
     {
-        return $this->examples[$position];
+        return isset($this->examples[$position]) ? $this->examples[$position] : null;
     }
 
     /**

--- a/tests/ApiDefinitionTest.php
+++ b/tests/ApiDefinitionTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Routing\RouteCollection;
 
 class ApiDefinitionTest extends TestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         \setlocale(LC_NUMERIC, 'C');
@@ -465,7 +465,7 @@ class ApiDefinitionTest extends TestCase
     {
         $this->assertFalse($validator->isValid(), 'Validator expected to fail');
         foreach ($errors as $error) {
-            $this->assertContains(
+            $this->assertContainsEquals(
                 $error,
                 $validator->getErrors(),
                 $message = \sprintf('Validator expected to contain error: %s', $error->__toString()),

--- a/tests/JsonSchemaTest.php
+++ b/tests/JsonSchemaTest.php
@@ -13,7 +13,7 @@ class JsonSchemaTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();
@@ -32,7 +32,7 @@ class JsonSchemaTest extends TestCase
         $schema = $body->getSchema();
 
         $schemaString = (string) $schema;
-        $this->assertInternalType('string', $schemaString);
+        $this->assertIsString($schemaString);
         $this->assertEquals('A list of songs', \json_decode($schemaString)->description);
     }
 

--- a/tests/MethodTest.php
+++ b/tests/MethodTest.php
@@ -104,7 +104,7 @@ class MethodTest extends TestCase
             $apiDefinition
         );
 
-        $this->assertInternalType('array', $method->getResponses());
+        $this->assertIsArray($method->getResponses());
         $this->assertCount(1, $method->getResponses());
 
         $responses = $method->getResponses();
@@ -142,7 +142,7 @@ class MethodTest extends TestCase
             $apiDefinition
         );
 
-        $this->assertInternalType('array', $method->getProtocols());
+        $this->assertIsArray($method->getProtocols());
         $this->assertCount(1, $method->getProtocols());
         $this->assertSame(['HTTP'], $method->getProtocols());
     }
@@ -164,7 +164,7 @@ class MethodTest extends TestCase
             $apiDefinition
         );
 
-        $this->assertInternalType('array', $method->getProtocols());
+        $this->assertIsArray($method->getProtocols());
         $this->assertCount(2, $method->getProtocols());
         $this->assertSame([
             'HTTP',

--- a/tests/NamedParameters/BaseUriParameterTest.php
+++ b/tests/NamedParameters/BaseUriParameterTest.php
@@ -13,8 +13,9 @@ class BaseUriParameterTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->parser = new Parser();
         \setlocale(LC_NUMERIC, 'C');
     }

--- a/tests/NamedParameters/MultipleTypesTest.php
+++ b/tests/NamedParameters/MultipleTypesTest.php
@@ -14,7 +14,7 @@ class MultipleTypesTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();

--- a/tests/NamedParameters/ParameterTypesTest.php
+++ b/tests/NamedParameters/ParameterTypesTest.php
@@ -18,7 +18,7 @@ class ParameterTypesTest extends TestCase
      */
     private $validateBody;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();

--- a/tests/NamedParameters/UriParameterTest.php
+++ b/tests/NamedParameters/UriParameterTest.php
@@ -13,7 +13,7 @@ class UriParameterTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();

--- a/tests/NamedParameters/WebFormBodyTest.php
+++ b/tests/NamedParameters/WebFormBodyTest.php
@@ -15,7 +15,7 @@ class WebFormBodyTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();

--- a/tests/ParseTest.php
+++ b/tests/ParseTest.php
@@ -29,7 +29,7 @@ class ParseTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();
@@ -381,7 +381,7 @@ RAML;
         $body = $response->getBodyByType('application/json');
         $schema = $body->getSchema();
 
-        $this->assertInternalType('string', $schema);
+        $this->assertIsString($schema);
     }
 
     /**
@@ -455,7 +455,7 @@ RAML;
         $body = $response->getBodyByType('application/json');
         $schema = $body->getSchema();
 
-        $this->assertInternalType('string', $schema);
+        $this->assertIsString($schema);
     }
 
     /**

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -12,7 +12,7 @@ class TypeTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();

--- a/tests/Types/ArrayTest.php
+++ b/tests/Types/ArrayTest.php
@@ -14,7 +14,7 @@ class ArrayTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();

--- a/tests/Types/ObjectTypeTest.php
+++ b/tests/Types/ObjectTypeTest.php
@@ -14,7 +14,7 @@ class ObjectTypeTest extends TestCase
      */
     private $apiDefinition;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->apiDefinition = (new Parser())->parse(__DIR__ . '/../fixture/object_types.raml');

--- a/tests/Types/UnionTypeTest.php
+++ b/tests/Types/UnionTypeTest.php
@@ -12,7 +12,7 @@ class UnionTypeTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();

--- a/tests/Validator/RequestValidatorTest.php
+++ b/tests/Validator/RequestValidatorTest.php
@@ -3,6 +3,7 @@
 namespace Raml\Tests\Validator;
 
 use Negotiation\Negotiator;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -22,17 +23,18 @@ class RequestValidatorTest extends TestCase
     private $parser;
 
     /**
-     * @var RequestInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var RequestInterface&MockObject
      */
     private $request;
 
     /**
-     * @var UriInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var UriInterface&MockObject
      */
     private $uri;
 
-    protected function setUp()
+    protected function setUp(): void
     {
+        parent::setUp();
         $this->parser = new Parser();
         $this->uri = $this->createMock(UriInterface::class);
         $this->request = $this->createMock(RequestInterface::class);
@@ -163,7 +165,6 @@ class RequestValidatorTest extends TestCase
 
     /**
      * @test
-     * @doesNotPerformAssertions
      */
     public function shouldParseContentTypeHeader()
     {

--- a/tests/Validator/ResponseValidatorTest.php
+++ b/tests/Validator/ResponseValidatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Raml\Tests\Validator;
 
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -22,21 +23,21 @@ class ResponseValidatorTest extends TestCase
     private $parser;
 
     /**
-     * @var RequestInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var RequestInterface&MockObject
      */
     private $request;
 
     /**
-     * @var ResponseInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var ResponseInterface&MockObject
      */
     private $response;
 
     /**
-     * @var UriInterface|PHPUnit_Framework_MockObject_MockObject
+     * @var UriInterface&MockObject
      */
     private $uri;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();
@@ -174,7 +175,6 @@ class ResponseValidatorTest extends TestCase
 
     /**
      * @test
-     * @doesNotPerformAssertions
      */
     public function shouldParseContentTypeHeader()
     {

--- a/tests/Validator/ValidatorSchemaHelperTest.php
+++ b/tests/Validator/ValidatorSchemaHelperTest.php
@@ -15,7 +15,7 @@ class ValidatorSchemaHelperTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();
@@ -112,8 +112,8 @@ class ValidatorSchemaHelperTest extends TestCase
         $allParameters = $helper->getQueryParameters('get', '/songs');
         $requiredParameters = $helper->getQueryParameters('get', '/songs', true);
 
-        $this->assertInternalType('array', $allParameters);
-        $this->assertInternalType('array', $requiredParameters);
+        $this->assertIsArray($allParameters);
+        $this->assertIsArray($requiredParameters);
 
         $this->assertSame(['required_number', 'optional_long_string'], \array_keys($allParameters));
         $this->assertSame(['required_number'], \array_keys($requiredParameters));
@@ -165,8 +165,8 @@ class ValidatorSchemaHelperTest extends TestCase
         $allHeaders = $helper->getResponseHeaders('get', '/songs', 200);
         $requiredHeaders = $helper->getResponseHeaders('get', '/songs', 200, true);
 
-        $this->assertInternalType('array', $allHeaders);
-        $this->assertInternalType('array', $requiredHeaders);
+        $this->assertIsArray($allHeaders);
+        $this->assertIsArray($requiredHeaders);
 
         $this->assertSame(['X-Required-Header', 'X-Long-Optional-Header'], \array_keys($allHeaders));
         $this->assertSame(['X-Required-Header'], \array_keys($requiredHeaders));

--- a/tests/XmlSchemaTest.php
+++ b/tests/XmlSchemaTest.php
@@ -15,7 +15,7 @@ class XmlSchemaTest extends TestCase
      */
     private $parser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->parser = new Parser();
@@ -119,7 +119,7 @@ XML
      */
     public function shouldConvertXmlToString()
     {
-        $this->assertInternalType('string', (string) $this->loadXmlSchema());
+        $this->assertIsString((string) $this->loadXmlSchema());
     }
 
     /**
@@ -156,7 +156,7 @@ XML
     {
         $this->assertFalse($validator->isValid(), 'Validator expected to fail');
         foreach ($errors as $error) {
-            $this->assertContains(
+            $this->assertContainsEquals(
                 $error,
                 $validator->getErrors(),
                 $message = \sprintf('Validator expected to contain error: %s', $error->__toString()),

--- a/tools/php-cs-fixer/config.php
+++ b/tools/php-cs-fixer/config.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+$rootFolder = __DIR__.'/../../';
+
 $finder = PhpCsFixer\Finder::create()
-    ->in(__DIR__.'/src')
-    ->in(__DIR__.'/tests');
+    ->in($rootFolder.'/src')
+    ->in($rootFolder.'/tests');
 
 return PhpCsFixer\Config::create()
     ->setRules(
@@ -53,7 +55,6 @@ return PhpCsFixer\Config::create()
             'phpdoc_single_line_var_spacing' => false,
             'phpdoc_summary' => false,
             'phpdoc_to_comment' => false,
-            'phpdoc_to_comment' => false,
             'phpdoc_to_return_type' => false,
             'phpdoc_trim' => false,
             'phpdoc_trim_consecutive_blank_line_separation' => false,
@@ -62,7 +63,6 @@ return PhpCsFixer\Config::create()
             'phpdoc_var_annotation_correct_order' => false,
             'phpdoc_var_without_name' => false,
          //   'phpdoc_types_order' => ['null_adjustment' => 'always_last'],
-            'phpdoc_types_order' => false,
             'simplified_null_return' => true,
             'single_line_comment_style' => false,
             'static_lambda' => true,

--- a/tools/phpstan/baseline/src.neon
+++ b/tools/phpstan/baseline/src.neon
@@ -1,0 +1,1672 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Call to function assert\\(\\) with false will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Instanceof between resource and Raml\\\\Resource will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Cannot call method getUri\\(\\) on resource\\.$#"
+			count: 3
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Cannot call method getResources\\(\\) on resource\\.$#"
+			count: 2
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:setBaseUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:setBaseUri\\(\\) has parameter \\$baseUrl with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function strtoupper expects string, string\\|false\\|null given\\.$#"
+			count: 2
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:addBaseUriParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:addProtocol\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:setDefaultMediaType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:addSchemaCollection\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:addSchema\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:addDocumentation\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:getStraightForwardTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Call to function is_string\\(\\) with array will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Else branch is unreachable because previous condition is always true\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Parameter \\#1 \\$function of function forward_static_call_array expects callable\\(\\)\\: mixed, array\\(class\\-string, 'createFromArray'\\) given\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:addType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:addTrait\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:addResource\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Array \\(array\\<resource\\>\\) does not accept Raml\\\\Resource\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:removeResource\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:addSecurityScheme\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:addSecuredBy\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Cannot call method getMethods\\(\\) on resource\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Cannot call method getUriParameters\\(\\) on resource\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Method Raml\\\\ApiDefinition\\:\\:setProtocolsFromBaseUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ApiDefinition.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/Body.php
+
+		-
+			message: "#^Method Raml\\\\Body\\:\\:setDescription\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Body.php
+
+		-
+			message: "#^Ternary operator condition is always true\\.$#"
+			count: 1
+			path: ../../../src/Body.php
+
+		-
+			message: "#^Method Raml\\\\Body\\:\\:setSchema\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Body.php
+
+		-
+			message: "#^Result of && is always false\\.$#"
+			count: 1
+			path: ../../../src/Body.php
+
+		-
+			message: "#^Method Raml\\\\Body\\:\\:setType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Body.php
+
+		-
+			message: "#^Method Raml\\\\Body\\:\\:addExample\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Body.php
+
+		-
+			message: "#^Property Raml\\\\Exception\\\\BadParameter\\\\FileNotFoundException\\:\\:\\$fileName has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/BadParameter/FileNotFoundException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\BadParameter\\\\FileNotFoundException\\:\\:__construct\\(\\) has parameter \\$fileName with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/BadParameter/FileNotFoundException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\BadParameter\\\\FileNotFoundException\\:\\:getFileName\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/BadParameter/FileNotFoundException.php
+
+		-
+			message: "#^Property Raml\\\\Exception\\\\BadParameter\\\\ResourceNotFoundException\\:\\:\\$uri has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/BadParameter/ResourceNotFoundException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\BadParameter\\\\ResourceNotFoundException\\:\\:__construct\\(\\) has parameter \\$uri with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/BadParameter/ResourceNotFoundException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\BadParameter\\\\ResourceNotFoundException\\:\\:getUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/BadParameter/ResourceNotFoundException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\EmptyBodyException\\:\\:__construct\\(\\) has parameter \\$code with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/EmptyBodyException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\EmptyBodyException\\:\\:__construct\\(\\) has parameter \\$message with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/EmptyBodyException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\EmptyBodyException\\:\\:__construct\\(\\) has parameter \\$previous with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/EmptyBodyException.php
+
+		-
+			message: "#^Property Raml\\\\Exception\\\\InvalidJsonException\\:\\:\\$errorCode has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidJsonException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\InvalidJsonException\\:\\:__construct\\(\\) has parameter \\$errorCode with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidJsonException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\InvalidJsonException\\:\\:getErrorCode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidJsonException.php
+
+		-
+			message: "#^Property Raml\\\\Exception\\\\InvalidKeyException\\:\\:\\$key has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidKeyException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\InvalidKeyException\\:\\:__construct\\(\\) has parameter \\$key with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidKeyException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\InvalidKeyException\\:\\:getKey\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidKeyException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\InvalidQueryParameterTypeException\\:\\:__construct\\(\\) has parameter \\$type with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidQueryParameterTypeException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\InvalidQueryParameterTypeException\\:\\:getType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidQueryParameterTypeException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\InvalidQueryParameterTypeException\\:\\:getValidTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidQueryParameterTypeException.php
+
+		-
+			message: "#^Property Raml\\\\Exception\\\\InvalidSchemaException\\:\\:\\$errors has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidSchemaException.php
+
+		-
+			message: "#^Method Raml\\\\Exception\\\\InvalidSchemaException\\:\\:getErrors\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidSchemaException.php
+
+		-
+			message: "#^Parameter \\#2 \\$pieces of function implode expects array, array\\|string given\\.$#"
+			count: 1
+			path: ../../../src/Exception/InvalidXmlException.php
+
+		-
+			message: "#^Method Raml\\\\FileLoader\\\\DefaultFileLoader\\:\\:loadFile\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: ../../../src/FileLoader/DefaultFileLoader.php
+
+		-
+			message: "#^Method Raml\\\\FileLoader\\\\JsonSchemaFileLoader\\:\\:loadFile\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: ../../../src/FileLoader/JsonSchemaFileLoader.php
+
+		-
+			message: "#^Method Raml\\\\MessageSchemaInterface\\:\\:addHeader\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/MessageSchemaInterface.php
+
+		-
+			message: "#^Method Raml\\\\MessageSchemaInterface\\:\\:addBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/MessageSchemaInterface.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Cannot call method getSecurityScheme\\(\\) on Raml\\\\ApiDefinition\\|null\\.$#"
+			count: 2
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Method Raml\\\\Method\\:\\:setDescription\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Method Raml\\\\Method\\:\\:setDisplayName\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Method Raml\\\\Method\\:\\:addBaseUriParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Method Raml\\\\Method\\:\\:addHeader\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Cannot access offset 'example' on Raml\\\\BodyInterface\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Method Raml\\\\Method\\:\\:addProtocol\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Method Raml\\\\Method\\:\\:addQueryParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Method Raml\\\\Method\\:\\:addBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Method Raml\\\\Method\\:\\:getResponse\\(\\) should return Raml\\\\Response but returns Raml\\\\Response\\|null\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Method Raml\\\\Method\\:\\:addResponse\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Method Raml\\\\Method\\:\\:addSecurityScheme\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^If condition is always true\\.$#"
+			count: 1
+			path: ../../../src/Method.php
+
+		-
+			message: "#^Property Raml\\\\NamedParameter\\:\\:\\$default has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setDisplayName\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setDescription\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setEnum\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setValidationPattern\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setMinLength\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setMaxLength\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setMinimum\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setMaximum\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:addExample\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setRepeat\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setRequired\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:getDefault\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setFormat\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setDefault\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:setDefault\\(\\) has parameter \\$default with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\NamedParameter\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/NamedParameter.php
+
+		-
+			message: "#^Method Raml\\\\ParseConfiguration\\:\\:enableDirectoryTraversal\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ParseConfiguration.php
+
+		-
+			message: "#^Method Raml\\\\ParseConfiguration\\:\\:disableDirectoryTraversal\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ParseConfiguration.php
+
+		-
+			message: "#^Method Raml\\\\ParseConfiguration\\:\\:enableSchemaParsing\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ParseConfiguration.php
+
+		-
+			message: "#^Method Raml\\\\ParseConfiguration\\:\\:disableSchemaParsing\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ParseConfiguration.php
+
+		-
+			message: "#^Method Raml\\\\ParseConfiguration\\:\\:enableSecuritySchemeParsing\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ParseConfiguration.php
+
+		-
+			message: "#^Method Raml\\\\ParseConfiguration\\:\\:disableSecuritySchemeParsing\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ParseConfiguration.php
+
+		-
+			message: "#^Method Raml\\\\ParseConfiguration\\:\\:allowRemoteFileInclusion\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ParseConfiguration.php
+
+		-
+			message: "#^Method Raml\\\\ParseConfiguration\\:\\:forbidRemoteFileInclusion\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ParseConfiguration.php
+
+		-
+			message: "#^Method Raml\\\\Parser\\:\\:setConfiguration\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Method Raml\\\\Parser\\:\\:addSchemaParser\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Method Raml\\\\Parser\\:\\:addType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Method Raml\\\\Parser\\:\\:addSecuritySettingParser\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Method Raml\\\\Parser\\:\\:addFileLoader\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function is_file expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$path of function dirname expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function file_get_contents expects string, string\\|false given\\.$#"
+			count: 2
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$ramlString of method Raml\\\\Parser\\:\\:parseRamlString\\(\\) expects string, string\\|false given\\.$#"
+			count: 2
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Method Raml\\\\Parser\\:\\:parseResourceTypes\\(\\) has parameter \\$ramlData with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Method Raml\\\\Parser\\:\\:parseRamlString\\(\\) should return array but returns array\\|string\\|Symfony\\\\Component\\\\Yaml\\\\Tag\\\\TaggedValue\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$filename of function is_readable expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$filePath of method Raml\\\\FileLoader\\\\FileLoaderInterface\\:\\:loadFile\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Method Raml\\\\Parser\\:\\:loadAndParseFile\\(\\) should return array but returns array\\|string\\|Symfony\\\\Component\\\\Yaml\\\\Tag\\\\TaggedValue\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|Symfony\\\\Component\\\\Yaml\\\\Tag\\\\TaggedValue given\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|Symfony\\\\Component\\\\Yaml\\\\Tag\\\\TaggedValue given\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#2 \\$arr2 of function array_replace_recursive expects array, array\\|string given\\.$#"
+			count: 3
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Method Raml\\\\Parser\\:\\:replaceTypes\\(\\) should return array but returns array\\|string\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|null given\\.$#"
+			count: 2
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Method Raml\\\\Parser\\:\\:getIncludedFiles\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Parser.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Cannot call method getSecurityScheme\\(\\) on Raml\\\\ApiDefinition\\|null\\.$#"
+			count: 2
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#"
+			count: 1
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Method Raml\\\\Resource\\:\\:setDisplayName\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Method Raml\\\\Resource\\:\\:setDescription\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Method Raml\\\\Resource\\:\\:addBaseUriParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Method Raml\\\\Resource\\:\\:addUriParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Method Raml\\\\Resource\\:\\:addResource\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Parameter \\#1 \\$parentResource of method Raml\\\\Resource\\:\\:setParentResource\\(\\) expects resource, \\$this\\(Raml\\\\Resource\\) given\\.$#"
+			count: 1
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Method Raml\\\\Resource\\:\\:addMethod\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Method Raml\\\\Resource\\:\\:addSecurityScheme\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Resource.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/Response.php
+
+		-
+			message: "#^Method Raml\\\\Response\\:\\:addBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Response.php
+
+		-
+			message: "#^Method Raml\\\\Response\\:\\:addHeader\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Response.php
+
+		-
+			message: "#^Method Raml\\\\Response\\:\\:setDescription\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Response.php
+
+		-
+			message: "#^Method Raml\\\\RouteFormatter\\\\RouteFormatterInterface\\:\\:getRoutes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/RouteFormatter/RouteFormatterInterface.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false\\|null given\\.$#"
+			count: 1
+			path: ../../../src/RouteFormatter/SymfonyRouteFormatter.php
+
+		-
+			message: "#^Parameter \\#2 \\$needle of function strpos expects int\\|string, string\\|false\\|null given\\.$#"
+			count: 1
+			path: ../../../src/RouteFormatter/SymfonyRouteFormatter.php
+
+		-
+			message: "#^Method Raml\\\\RouteFormatter\\\\SymfonyRouteFormatter\\:\\:getRoutes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/RouteFormatter/SymfonyRouteFormatter.php
+
+		-
+			message: "#^Property Raml\\\\Schema\\\\Definition\\\\JsonSchemaDefinition\\:\\:\\$errors has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Schema/Definition/JsonSchemaDefinition.php
+
+		-
+			message: "#^Method Raml\\\\Schema\\\\Definition\\\\JsonSchemaDefinition\\:\\:__toString\\(\\) should return string but returns string\\|false\\.$#"
+			count: 1
+			path: ../../../src/Schema/Definition/JsonSchemaDefinition.php
+
+		-
+			message: "#^Method Raml\\\\Schema\\\\Definition\\\\JsonSchemaDefinition\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Schema/Definition/JsonSchemaDefinition.php
+
+		-
+			message: "#^Method Raml\\\\Schema\\\\Definition\\\\JsonSchemaDefinition\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Schema/Definition/JsonSchemaDefinition.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: ../../../src/Schema/Definition/JsonSchemaDefinition.php
+
+		-
+			message: "#^Property Raml\\\\Schema\\\\Definition\\\\XmlSchemaDefinition\\:\\:\\$errors has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Schema/Definition/XmlSchemaDefinition.php
+
+		-
+			message: "#^Method Raml\\\\Schema\\\\Definition\\\\XmlSchemaDefinition\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Schema/Definition/XmlSchemaDefinition.php
+
+		-
+			message: "#^Method Raml\\\\Schema\\\\Definition\\\\XmlSchemaDefinition\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Schema/Definition/XmlSchemaDefinition.php
+
+		-
+			message: "#^Parameter \\#1 \\$data of method Raml\\\\Schema\\\\Parser\\\\JsonSchemaParser\\:\\:resolveRefSchemaRecursively\\(\\) expects stdClass\\|string, object given\\.$#"
+			count: 2
+			path: ../../../src/Schema/Parser/JsonSchemaParser.php
+
+		-
+			message: "#^Method Raml\\\\Schema\\\\Parser\\\\JsonSchemaParser\\:\\:resolveRefSchemaRecursively\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Schema/Parser/JsonSchemaParser.php
+
+		-
+			message: "#^Argument of an invalid type object supplied for foreach, only iterables are supported\\.$#"
+			count: 1
+			path: ../../../src/Schema/Parser/JsonSchemaParser.php
+
+		-
+			message: "#^Method Raml\\\\Schema\\\\SchemaParserAbstract\\:\\:setSourceUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Schema/SchemaParserAbstract.php
+
+		-
+			message: "#^Method Raml\\\\Schema\\\\SchemaParserAbstract\\:\\:addCompatibleContentType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Schema/SchemaParserAbstract.php
+
+		-
+			message: "#^Method Raml\\\\Schema\\\\SchemaParserInterface\\:\\:setSourceUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Schema/SchemaParserInterface.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\:\\:getKey\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\:\\:setDescription\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\:\\:setType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\:\\:setDescribedBy\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\:\\:setSettings\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme.php
+
+		-
+			message: "#^Property Raml\\\\SecurityScheme\\:\\:\\$settings \\(object\\) does not accept array\\|object\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\:\\:mergeSettings\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySchemeDescribedBy.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySchemeDescribedBy\\:\\:addBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySchemeDescribedBy.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySchemeDescribedBy\\:\\:addHeader\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySchemeDescribedBy.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySchemeDescribedBy\\:\\:addQueryParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySchemeDescribedBy.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySchemeDescribedBy\\:\\:getResponse\\(\\) should return Raml\\\\Response but returns Raml\\\\Response\\|null\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySchemeDescribedBy.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySchemeDescribedBy\\:\\:addResponse\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySchemeDescribedBy.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/DefaultSecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\DefaultSecuritySettings\\:\\:mergeSettings\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/DefaultSecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\DefaultSecuritySettings\\:\\:offsetSet\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/DefaultSecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\DefaultSecuritySettings\\:\\:offsetSet\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/DefaultSecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\DefaultSecuritySettings\\:\\:offsetExists\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/DefaultSecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\DefaultSecuritySettings\\:\\:offsetUnset\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/DefaultSecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\DefaultSecuritySettings\\:\\:offsetGet\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/DefaultSecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\DefaultSecuritySettings\\:\\:offsetGet\\(\\) has parameter \\$offset with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/DefaultSecuritySettings.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/OAuth1SecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\OAuth1SecuritySettings\\:\\:setTokenCredentialsUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/OAuth1SecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\OAuth1SecuritySettings\\:\\:setRequestTokenUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/OAuth1SecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\OAuth1SecuritySettings\\:\\:setAuthorizationUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/OAuth1SecuritySettings.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/OAuth2SecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\OAuth2SecuritySettings\\:\\:setAuthorizationUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/OAuth2SecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\OAuth2SecuritySettings\\:\\:setAccessTokenUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/OAuth2SecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\OAuth2SecuritySettings\\:\\:addAuthorizationGrants\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/OAuth2SecuritySettings.php
+
+		-
+			message: "#^Method Raml\\\\SecurityScheme\\\\SecuritySettings\\\\OAuth2SecuritySettings\\:\\:addScope\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettings/OAuth2SecuritySettings.php
+
+		-
+			message: "#^Return type \\(Raml\\\\SecurityScheme\\\\SecuritySettings\\\\DefaultSecuritySettings\\) of method Raml\\\\SecurityScheme\\\\SecuritySettingsParser\\\\DefaultSecuritySettingsParser\\:\\:createSecuritySettings\\(\\) should be compatible with return type \\(array\\<object\\>\\) of method Raml\\\\SecurityScheme\\\\SecuritySettingsParserInterface\\:\\:createSecuritySettings\\(\\)$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettingsParser/DefaultSecuritySettingsParser.php
+
+		-
+			message: "#^Return type \\(Raml\\\\SecurityScheme\\\\SecuritySettings\\\\OAuth1SecuritySettings\\) of method Raml\\\\SecurityScheme\\\\SecuritySettingsParser\\\\OAuth1SecuritySettingsParser\\:\\:createSecuritySettings\\(\\) should be compatible with return type \\(array\\<object\\>\\) of method Raml\\\\SecurityScheme\\\\SecuritySettingsParserInterface\\:\\:createSecuritySettings\\(\\)$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettingsParser/OAuth1SecuritySettingsParser.php
+
+		-
+			message: "#^Return type \\(Raml\\\\SecurityScheme\\\\SecuritySettings\\\\OAuth2SecuritySettings\\) of method Raml\\\\SecurityScheme\\\\SecuritySettingsParser\\\\OAuth2SecuritySettingsParser\\:\\:createSecuritySettings\\(\\) should be compatible with return type \\(array\\<object\\>\\) of method Raml\\\\SecurityScheme\\\\SecuritySettingsParserInterface\\:\\:createSecuritySettings\\(\\)$#"
+			count: 1
+			path: ../../../src/SecurityScheme/SecuritySettingsParser/OAuth2SecuritySettingsParser.php
+
+		-
+			message: "#^Method Raml\\\\TraitCollection\\:\\:add\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TraitCollection.php
+
+		-
+			message: "#^Method Raml\\\\TraitCollection\\:\\:remove\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TraitCollection.php
+
+		-
+			message: "#^Call to function is_array\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/TraitCollection.php
+
+		-
+			message: "#^Method Raml\\\\TraitCollection\\:\\:clear\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TraitCollection.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/TraitDefinition.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Call to function assert\\(\\) with false will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Instanceof between static\\(Raml\\\\Type\\) and Raml\\\\TraitDefinition will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Method Raml\\\\Type\\:\\:discriminate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Method Raml\\\\Type\\:\\:discriminate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Method Raml\\\\Type\\:\\:setDefinition\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Method Raml\\\\Type\\:\\:setEnum\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Property Raml\\\\Type\\:\\:\\$parent \\(Raml\\\\Types\\\\ObjectType\\|string\\) does not accept Raml\\\\Type\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Parameter \\#1 \\$var of function count expects array\\|Countable, array\\<int, string\\>\\|false given\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Cannot access offset 0 on array\\<int, string\\>\\|false\\.$#"
+			count: 2
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Cannot access offset 1 on array\\<int, string\\>\\|false\\.$#"
+			count: 2
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Method Raml\\\\Type\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Method Raml\\\\Type\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Type.php
+
+		-
+			message: "#^Property Raml\\\\TypeCollection\\:\\:\\$position \\(string\\) does not accept default value of type int\\.$#"
+			count: 1
+			path: ../../../src/TypeCollection.php
+
+		-
+			message: "#^Method Raml\\\\TypeCollection\\:\\:current\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TypeCollection.php
+
+		-
+			message: "#^Method Raml\\\\TypeCollection\\:\\:key\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TypeCollection.php
+
+		-
+			message: "#^Property Raml\\\\TypeCollection\\:\\:\\$position \\(string\\) does not accept int\\.$#"
+			count: 2
+			path: ../../../src/TypeCollection.php
+
+		-
+			message: "#^Method Raml\\\\TypeCollection\\:\\:add\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TypeCollection.php
+
+		-
+			message: "#^Method Raml\\\\TypeCollection\\:\\:remove\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TypeCollection.php
+
+		-
+			message: "#^Method Raml\\\\TypeCollection\\:\\:applyInheritance\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TypeCollection.php
+
+		-
+			message: "#^Call to an undefined method Raml\\\\TypeInterface\\:\\:toArray\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/TypeCollection.php
+
+		-
+			message: "#^Method Raml\\\\TypeCollection\\:\\:clear\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TypeCollection.php
+
+		-
+			message: "#^Method Raml\\\\TypeInterface\\:\\:getName\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TypeInterface.php
+
+		-
+			message: "#^Method Raml\\\\TypeInterface\\:\\:discriminate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TypeInterface.php
+
+		-
+			message: "#^Method Raml\\\\TypeInterface\\:\\:discriminate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/TypeInterface.php
+
+		-
+			message: "#^Property Raml\\\\Types\\\\ArrayType\\:\\:\\$SCALAR_TYPES has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ArrayType\\:\\:setUniqueItems\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ArrayType\\:\\:setItems\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ArrayType\\:\\:setMinItems\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ArrayType\\:\\:setMaxItems\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ArrayType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ArrayType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ArrayType\\:\\:validateScalars\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ArrayType\\:\\:validateScalars\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ArrayType\\:\\:validateObjects\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ArrayType\\:\\:validateObjects\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ArrayType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\BooleanType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/BooleanType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\BooleanType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/BooleanType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\DateOnlyType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/DateOnlyType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\DateOnlyType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/DateOnlyType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\DatetimeOnlyType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/DatetimeOnlyType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\DatetimeOnlyType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/DatetimeOnlyType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\DatetimeType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/DatetimeType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\DatetimeType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/DatetimeType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\FileType\\:\\:getFileTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/FileType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\FileType\\:\\:setFileTypes\\(\\) has parameter \\$fileTypes with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/FileType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\FileType\\:\\:getMinLength\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/FileType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\FileType\\:\\:setMinLength\\(\\) has parameter \\$minLength with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/FileType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\FileType\\:\\:getMaxLength\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/FileType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\FileType\\:\\:setMaxLength\\(\\) has parameter \\$maxLength with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/FileType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\FileType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/FileType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\FileType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/FileType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\JsonType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/JsonType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\JsonType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/JsonType.php
+
+		-
+			message: "#^Parameter \\#1 \\$function of function call_user_func_array expects callable\\(\\)\\: mixed, array\\(Raml\\\\Type, string\\) given\\.$#"
+			count: 1
+			path: ../../../src/Types/LazyProxyType.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/Types/LazyProxyType.php
+
+		-
+			message: "#^Cannot assign offset string to string\\.$#"
+			count: 1
+			path: ../../../src/Types/LazyProxyType.php
+
+		-
+			message: "#^Call to an undefined method Raml\\\\Type\\:\\:getDiscriminator\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/Types/LazyProxyType.php
+
+		-
+			message: "#^Call to an undefined method Raml\\\\Type\\:\\:getDiscriminatorValue\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/Types/LazyProxyType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\LazyProxyType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/LazyProxyType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\LazyProxyType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/LazyProxyType.php
+
+		-
+			message: "#^Property Raml\\\\Types\\\\LazyProxyType\\:\\:\\$wrappedObject \\(Raml\\\\Type\\) does not accept Raml\\\\TypeInterface\\.$#"
+			count: 1
+			path: ../../../src/Types/LazyProxyType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\NullType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/NullType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\NullType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/NullType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\NumberType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/NumberType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\NumberType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/NumberType.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: ../../../src/Types/ObjectType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ObjectType\\:\\:getAdditionalProperties\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ObjectType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ObjectType\\:\\:setAdditionalProperties\\(\\) has parameter \\$additionalProperties with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ObjectType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ObjectType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ObjectType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\ObjectType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/ObjectType.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between Raml\\\\Type\\|void and null will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/Types/ObjectType.php
+
+		-
+			message: "#^Cannot call method validate\\(\\) on Raml\\\\Type\\|void\\.$#"
+			count: 1
+			path: ../../../src/Types/ObjectType.php
+
+		-
+			message: "#^Cannot call method isValid\\(\\) on Raml\\\\Type\\|void\\.$#"
+			count: 1
+			path: ../../../src/Types/ObjectType.php
+
+		-
+			message: "#^Cannot call method getErrors\\(\\) on Raml\\\\Type\\|void\\.$#"
+			count: 1
+			path: ../../../src/Types/ObjectType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\StringType\\:\\:getPattern\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/StringType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\StringType\\:\\:setPattern\\(\\) has parameter \\$pattern with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/StringType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\StringType\\:\\:getMinLength\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/StringType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\StringType\\:\\:setMinLength\\(\\) has parameter \\$minLength with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/StringType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\StringType\\:\\:getMaxLength\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/StringType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\StringType\\:\\:setMaxLength\\(\\) has parameter \\$maxLength with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/StringType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\StringType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/StringType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\StringType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/StringType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TimeOnlyType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TimeOnlyType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TimeOnlyType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TimeOnlyType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:__construct\\(\\) has parameter \\$constraint with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:__construct\\(\\) has parameter \\$property with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:unexpectedValue\\(\\) has parameter \\$actualValue with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:unexpectedValueType\\(\\) has parameter \\$actualValue with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:unexpectedValueType\\(\\) has parameter \\$constraint with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:unexpectedArrayValueType\\(\\) has parameter \\$actualValue with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:unexpectedArrayValueType\\(\\) has parameter \\$constraint with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:valueExceedsMinimum\\(\\) has parameter \\$actualValue with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:valueExceedsMinimum\\(\\) has parameter \\$minValue with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:valueExceedsMaximum\\(\\) has parameter \\$actualValue with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\TypeValidationError\\:\\:valueExceedsMaximum\\(\\) has parameter \\$maxValue with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/TypeValidationError.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\UnionType\\:\\:getPropertyByName\\(\\) should return Raml\\\\Type\\|null but return statement is missing\\.$#"
+			count: 1
+			path: ../../../src/Types/UnionType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\UnionType\\:\\:getAdditionalProperties\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/UnionType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\UnionType\\:\\:setAdditionalProperties\\(\\) has parameter \\$additionalProperties with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/UnionType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\UnionType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/UnionType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\UnionType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/UnionType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\XmlType\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/XmlType.php
+
+		-
+			message: "#^Method Raml\\\\Types\\\\XmlType\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Types/XmlType.php
+
+		-
+			message: "#^Parameter \\#1 \\$source of method DOMDocument\\:\\:schemaValidateSource\\(\\) expects string, array given\\.$#"
+			count: 1
+			path: ../../../src/Types/XmlType.php
+
+		-
+			message: "#^Static property Raml\\\\Utility\\\\StringTransformer\\:\\:\\$possibleTransformations \\(array\\<string\\>\\) does not accept default value of type array\\<int, int\\>\\.$#"
+			count: 1
+			path: ../../../src/Utility/StringTransformer.php
+
+		-
+			message: "#^Call to function in_array\\(\\) with arguments int, array\\<string\\> and true will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/Utility/StringTransformer.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: ../../../src/Utility/StringTransformer.php
+
+		-
+			message: "#^Method Raml\\\\Utility\\\\TraitParserHelper\\:\\:applyFunctions\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: ../../../src/Utility/TraitParserHelper.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 10
+			path: ../../../src/Utility/TraitParserHelper.php
+
+		-
+			message: "#^Property Raml\\\\Validator\\\\ContentConverter\\:\\:\\$jsonTypes has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ContentConverter.php
+
+		-
+			message: "#^Property Raml\\\\Validator\\\\ContentConverter\\:\\:\\$xmlTypes has no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ContentConverter.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\ContentConverter\\:\\:convertStringByContentType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ContentConverter.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\ContentConverter\\:\\:convertStringByContentType\\(\\) has parameter \\$contentType with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ContentConverter.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\ContentConverter\\:\\:convertStringByContentType\\(\\) has parameter \\$string with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ContentConverter.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\ContentConverter\\:\\:parseMediaRange\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ContentConverter.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\ContentConverter\\:\\:parseMediaRange\\(\\) has parameter \\$mediaRange with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ContentConverter.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\RequestValidator\\:\\:validateRequest\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/RequestValidator.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\RequestValidator\\:\\:assertNoMissingParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/RequestValidator.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\RequestValidator\\:\\:assertValidParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/RequestValidator.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\RequestValidator\\:\\:assertValidBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/RequestValidator.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\RequestValidator\\:\\:assertMediaTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/RequestValidator.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\RequestValidator\\:\\:getTypeValidationErrorsAsString\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/RequestValidator.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\ResponseValidator\\:\\:validateResponse\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ResponseValidator.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\ResponseValidator\\:\\:assertNoMissingHeaders\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ResponseValidator.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\ResponseValidator\\:\\:assertValidHeaders\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ResponseValidator.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\ResponseValidator\\:\\:assertValidBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ResponseValidator.php
+
+		-
+			message: "#^Method Raml\\\\Validator\\\\ResponseValidator\\:\\:getTypeValidationErrorsAsString\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/Validator/ResponseValidator.php
+
+		-
+			message: "#^Strict comparison using \\=\\=\\= between null and Raml\\\\Response will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/Validator/ValidatorSchemaHelper.php
+
+		-
+			message: "#^Call to function assert\\(\\) with false will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/Validator/ValidatorSchemaHelper.php
+
+		-
+			message: "#^Instanceof between resource and Raml\\\\Resource will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../src/Validator/ValidatorSchemaHelper.php
+
+		-
+			message: "#^Method Raml\\\\ValidatorInterface\\:\\:validate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ValidatorInterface.php
+
+		-
+			message: "#^Method Raml\\\\ValidatorInterface\\:\\:validate\\(\\) has parameter \\$value with no typehint specified\\.$#"
+			count: 1
+			path: ../../../src/ValidatorInterface.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: ../../../src/WebFormBody.php
+
+		-
+			message: "#^Method Raml\\\\WebFormBody\\:\\:addParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../src/WebFormBody.php
+

--- a/tools/phpstan/baseline/src.neon
+++ b/tools/phpstan/baseline/src.neon
@@ -36,7 +36,7 @@ parameters:
 			path: ../../../src/ApiDefinition.php
 
 		-
-			message: "#^Parameter \\#1 \\$str of function strtoupper expects string, string\\|false\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$str of function mb_strtoupper expects string, string\\|false\\|null given\\.$#"
 			count: 2
 			path: ../../../src/ApiDefinition.php
 
@@ -571,7 +571,7 @@ parameters:
 			path: ../../../src/Parser.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|false given\\.$#"
+			message: "#^Parameter \\#1 \\$haystack of function mb_strpos expects string, string\\|false given\\.$#"
 			count: 1
 			path: ../../../src/Parser.php
 
@@ -586,12 +586,12 @@ parameters:
 			path: ../../../src/Parser.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false given\\.$#"
+			message: "#^Parameter \\#1 \\$str of function mb_strlen expects string, string\\|false given\\.$#"
 			count: 1
 			path: ../../../src/Parser.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|false given\\.$#"
+			message: "#^Parameter \\#1 \\$str of function mb_substr expects string, string\\|false given\\.$#"
 			count: 1
 			path: ../../../src/Parser.php
 
@@ -611,7 +611,7 @@ parameters:
 			path: ../../../src/Parser.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|Symfony\\\\Component\\\\Yaml\\\\Tag\\\\TaggedValue given\\.$#"
+			message: "#^Parameter \\#1 \\$haystack of function mb_strpos expects string, string\\|Symfony\\\\Component\\\\Yaml\\\\Tag\\\\TaggedValue given\\.$#"
 			count: 1
 			path: ../../../src/Parser.php
 
@@ -631,7 +631,7 @@ parameters:
 			path: ../../../src/Parser.php
 
 		-
-			message: "#^Parameter \\#1 \\$haystack of function strpos expects string, string\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$haystack of function mb_strpos expects string, string\\|null given\\.$#"
 			count: 2
 			path: ../../../src/Parser.php
 
@@ -721,12 +721,12 @@ parameters:
 			path: ../../../src/RouteFormatter/RouteFormatterInterface.php
 
 		-
-			message: "#^Parameter \\#1 \\$string of function strlen expects string, string\\|false\\|null given\\.$#"
+			message: "#^Parameter \\#1 \\$str of function mb_strlen expects string, string\\|false\\|null given\\.$#"
 			count: 1
 			path: ../../../src/RouteFormatter/SymfonyRouteFormatter.php
 
 		-
-			message: "#^Parameter \\#2 \\$needle of function strpos expects int\\|string, string\\|false\\|null given\\.$#"
+			message: "#^Parameter \\#2 \\$needle of function mb_strpos expects string, string\\|false\\|null given\\.$#"
 			count: 1
 			path: ../../../src/RouteFormatter/SymfonyRouteFormatter.php
 

--- a/tools/phpstan/baseline/tests.neon
+++ b/tools/phpstan/baseline/tests.neon
@@ -1,0 +1,1157 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldReturnFullResourcesForRamlFileWithDefaultFormatter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldReturnFullResourcesForRamlFileWithNoFormatter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldReturnFullResourcesForRamlFileWithSymfonyFormatter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldReturnURIProtocol\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldProcessTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldBeAbleToAccessOriginalInheritanceTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldParseLibraries\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldParseTypesToSubTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldParseComplexTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Cannot call method getResolvedObject\\(\\) on Raml\\\\Type\\|void\\.$#"
+			count: 2
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Cannot call method getPropertyByName\\(\\) on Raml\\\\Type\\|void\\.$#"
+			count: 6
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 6
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldPassValidResponse\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldRejectMissingParameterResponse\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldRejectInvalidIntegerParameterResponse\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldRejectInvalidStringParameterResponse\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldRejectInvalidEnumParameterResponse\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldReturnProtocolsIfSpecified\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldThrowInvalidProtocolExceptionIfWrongProtocol\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:assertValidationFailedWithErrors\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method PHPUnit\\\\Framework\\\\Assert\\:\\:assertContainsEquals\\(\\) invoked with 5 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Function assertValidationFailedWithErrors\\(\\) has an unused variable \\$message\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Function assertValidationFailedWithErrors\\(\\) has an unused variable \\$ignoreCase\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Function assertValidationFailedWithErrors\\(\\) has an unused variable \\$checkForObjectIdentity\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ApiDefinitionTest\\:\\:shouldReturnFullResourcesNameForRamlFileWithUrlPrefix\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ApiDefinitionTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\JsonSchemaTest\\:\\:shouldReturnJsonString\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/JsonSchemaTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 5
+			path: ../../../tests/JsonSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\JsonSchemaTest\\:\\:shouldCorrectlyValidateCorrectJson\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/JsonSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\JsonSchemaTest\\:\\:shouldCorrectlyValidateIncorrectJson\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/JsonSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\JsonSchemaTest\\:\\:shouldCorrectlyValidateInvalidJson\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/JsonSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\JsonSchemaTest\\:\\:shouldCorrectlyValidateJsonAsArray\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/JsonSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\MethodTest\\:\\:shouldGetTheTypeInUpperCase\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\MethodTest\\:\\:shouldGetTheDescriptionIfPassedInTheDataArray\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with string will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\MethodTest\\:\\:shouldGetTheDisplayNameIfPassedInTheDataArray\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\MethodTest\\:\\:shouldGetNullForResponseIfNoneIsExists\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\) with Raml\\\\Response will always evaluate to false\\.$#"
+			count: 3
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\MethodTest\\:\\:shouldGetNullForResponseIfNotAnArrayIsPassed\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\MethodTest\\:\\:shouldGetValidResponsesIfPassedExpectedValues\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\MethodTest\\:\\:shouldGetEmptyArrayForQueryParametersIfNoneIsExists\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\MethodTest\\:\\:shouldGetGlobalProtocols\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\MethodTest\\:\\:shouldGetOverrideProtocols\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/MethodTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\BaseUriParameterTest\\:\\:shouldCorrectlySubstituteTheVersion\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/BaseUriParameterTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\BaseUriParameterTest\\:\\:shouldCorrectlyParseBaseUriParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/BaseUriParameterTest.php
+
+		-
+			message: "#^Cannot call method getBaseUriParameters\\(\\) on resource\\.$#"
+			count: 2
+			path: ../../../tests/NamedParameters/BaseUriParameterTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\BaseUriParameterTest\\:\\:shouldOverrideBaseUriParametersInResource\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/BaseUriParameterTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\BaseUriParameterTest\\:\\:shouldOverrideBaseUriParametersInMethod\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/BaseUriParameterTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/BaseUriParameterTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\BaseUriParameterTest\\:\\:shouldCorrectlyParseNetBaseUri\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/BaseUriParameterTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\BaseUriParameterTest\\:\\:shouldOverrideBaseUriProtocols\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/BaseUriParameterTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\MultipleTypesTest\\:\\:shouldGetTheResourceOnTheBaseUrl\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/MultipleTypesTest.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Raml\\\\\\\\Resource' and resource will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/MultipleTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\MultipleTypesTest\\:\\:shouldReturnAnArrayOfTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/MultipleTypesTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/MultipleTypesTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateWithoutExceptions\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Call to an undefined method object\\:\\:getParameter\\(\\)\\.$#"
+			count: 24
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateRequired\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateString\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateShortString\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateLongString\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateNumber\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateSmallNumber\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateLargeNumber\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateInteger\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidatePattern\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateEnum\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateBoolean\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateDate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateDateOnly\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Class Raml\\\\Exception\\\\ValidationException should be written with \\:\\:class notation, string found\\.$#"
+			count: 5
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateDateTimeOnly\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateTimeOnly\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateDateTime\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldValidateDateTimeFormat\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldThrowExceptionOnInvalidString\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldThrowExceptionOnInvalidNumber\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldThrowExceptionOnInvalidInteger\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldThrowExceptionOnInvalidDate\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldThrowExceptionOnInvalidBoolean\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\ParameterTypesTest\\:\\:shouldThrowExceptionOnInvalidFile\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/ParameterTypesTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\UriParameterTest\\:\\:shouldCorrectlyParseBaseUriParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/UriParameterTest.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Raml\\\\\\\\Resource' and resource will always evaluate to false\\.$#"
+			count: 4
+			path: ../../../tests/NamedParameters/UriParameterTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\UriParameterTest\\:\\:shouldCorrectlyParseRegexUriParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/UriParameterTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\UriParameterTest\\:\\:shouldCorrectlyParseEnumUriParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/UriParameterTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\UriParameterTest\\:\\:shouldPassUriParametersFromParentToSub\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/UriParameterTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\WebFormBodyTest\\:\\:shouldThrowExceptionOnInvalidType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/WebFormBodyTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\WebFormBodyTest\\:\\:shouldBeCreatedForValidMediaTypeUrlEncoded\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/WebFormBodyTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 4
+			path: ../../../tests/NamedParameters/WebFormBodyTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\WebFormBodyTest\\:\\:shouldBeCreatedForValidMediaTypeFormData\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/WebFormBodyTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\WebFormBodyTest\\:\\:shouldThrowErrorOnAttemptGetInvalidParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/WebFormBodyTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\NamedParameters\\\\WebFormBodyTest\\:\\:shouldBeAbleToGetAllParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/NamedParameters/WebFormBodyTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldCorrectlyLoadASimpleRamlString\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldCorrectlyLoadASimpleRamlStringWithInclude\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldCorrectlyLoadASimpleRamlFile\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldThrowCorrectExceptionOnBadJson\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldThrowFileNotFoundExceptionOnBadRamlFileWithNotExistingFile\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldThrowExceptionOnPathManipulationIfNotAllowed\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldPreventDirectoryTraversalByDefault\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldNotThrowExceptionOnPathManipulationIfAllowed\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 41
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldCorrectlyReturnHttpProtocol\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldReturnAResourceObjectForAResource\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertInstanceOf\\(\\) with 'Raml\\\\\\\\Resource' and resource will always evaluate to false\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldThrowExceptionIfUriNotFound\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldNotMatchForwardSlashInURIParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldNotMatchForwardSlashAndDuplicationInURIParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldGiveTheResourceTheCorrectDisplayNameIfNotProvided\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Cannot call method getDisplayName\\(\\) on resource\\.$#"
+			count: 4
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldExcludeQueryParametersWhenFindingAResource\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldGiveTheResourceTheCorrectDisplayNameIfProvided\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseMultiLevelUrisAndParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldReturnAMethodObjectForAMethod\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Cannot call method getMethods\\(\\) on resource\\.$#"
+			count: 2
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldReturnAResponseForAResponse\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldReturnAnExampleForType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseJson\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseJsonSchemaInRaml\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldIncludeChildJsonObjects\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldNotParseJsonIfNotRequested\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseJsonRefs\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseJsonIntoArray\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseIncludedJson\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldNotParseIncludedJsonIfNotRequired\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseIncludedJsonRefs\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldSetCorrectSourceUriOnSchemaParsers\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldThrowErrorIfEmpty\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldThrowErrorIfNoTitle\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldBeAbleToAddAdditionalSchemaTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldApplyTraitVariables\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseIncludedRaml\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseIncludedYaml\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldIncludeTraits\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldThrowErrorIfPassedFileDoesNotExist\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseHateoasExample\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseMethodDescription\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseResourceDescription\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Cannot call method getDescription\\(\\) on resource\\.$#"
+			count: 6
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseStatusCode\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseMethodHeaders\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseResponseHeaders\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldReplaceReservedParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParameterTransformerWorks\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseSchemasDefinedInTheRoot\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldCorrectlyHandleQueryParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldThrowExceptionOnBadQueryParameter\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldReplaceParameterByJsonString\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseSecuritySchemes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldAddHeadersOfSecuritySchemes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldReplaceSchemaByRootSchema\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseAndReplaceSchemaOnlyInResources\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseInfoQExample\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldLoadATree\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldThrowExceptionOnInvalidBodyType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldSupportGenericResponseType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldMergeMethodSecurityScheme\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldAddSecuritySchemeToResource\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseCustomSettingsOnResource\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseCustomSettingsOnMethodWithOAuthParser\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseIncludedTraits\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseResourcePathNameCorrectly\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Cannot call method getResources\\(\\) on resource\\.$#"
+			count: 6
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldNestedResourcesHaveParentResourceDefined\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Cannot call method getParentResource\\(\\) on resource\\.$#"
+			count: 3
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseTraits\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Cannot call method getTraits\\(\\) on resource\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseResourceTypesAndTraits\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldParseOptionalMethods\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\ParseTest\\:\\:shouldNotHaveOptionalMethod\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/ParseTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateCorrectType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 11
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateCorrectTypeMissingUnrequired\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateCorrectTypeMissingRequired\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateIncorrectType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateAdditionalProperties\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateNullTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateRightDateTimeOnlyTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateWrongDateTimeOnlyTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateRightDateOnlyTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateWrongDateOnlyTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\TypeTest\\:\\:shouldCorrectlyValidateArrayScalarTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/TypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\ArrayTest\\:\\:shouldCorrectlyValidateCorrectType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/ArrayTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 4
+			path: ../../../tests/Types/ArrayTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\ArrayTest\\:\\:shouldCorrectlyValidateIncorrectArraySizeLessThanMinimum\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/ArrayTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\ArrayTest\\:\\:shouldCorrectlyParseTypeFacet\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/ArrayTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\ArrayTest\\:\\:shouldCorrectlyValidateIncorrectTypeWhenArraySizeExceedsMaximum\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/ArrayTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\ObjectTypeTest\\:\\:shouldCorrectlyValidateCorrectType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/ObjectTypeTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 2
+			path: ../../../tests/Types/ObjectTypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\ObjectTypeTest\\:\\:shouldNotCorrectlyValidateObjectType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/ObjectTypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\UnionTypeTest\\:\\:shouldCorrectlyValidateCorrectType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/UnionTypeTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 6
+			path: ../../../tests/Types/UnionTypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\UnionTypeTest\\:\\:shouldCorrectlyValidateIncorrectType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/UnionTypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\UnionTypeTest\\:\\:shouldCorrectlyValidateNullableTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/UnionTypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\UnionTypeTest\\:\\:shouldCorrectlyValidateNullableStringTypes\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/UnionTypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\UnionTypeTest\\:\\:shouldCorrectlyValidateUnionInheritedTypes1\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/UnionTypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Types\\\\UnionTypeTest\\:\\:shouldCorrectlyValidateUnionInheritedTypes2\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Types/UnionTypeTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\RequestValidatorTest\\:\\:shouldCatchWrongMediaType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/RequestValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\RequestValidatorTest\\:\\:shouldSuccessfullyAssertWildcardAcceptHeader\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/RequestValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\RequestValidatorTest\\:\\:shouldNotAssertBodyOnGetRequest\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/RequestValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\RequestValidatorTest\\:\\:shouldCatchMissingParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/RequestValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\RequestValidatorTest\\:\\:shouldCatchInvalidParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/RequestValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\RequestValidatorTest\\:\\:shouldCatchInvalidBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/RequestValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\RequestValidatorTest\\:\\:shouldAllowEmptyRequestBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/RequestValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\RequestValidatorTest\\:\\:shouldParseContentTypeHeader\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/RequestValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ResponseValidatorTest\\:\\:shouldCatchMissingHeaders\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ResponseValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ResponseValidatorTest\\:\\:shouldCatchInvalidHeaders\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ResponseValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ResponseValidatorTest\\:\\:shouldPassOnEmptyBodyIfNotRequired\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ResponseValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ResponseValidatorTest\\:\\:shouldCatchInvalidBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ResponseValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ResponseValidatorTest\\:\\:shouldParseContentTypeHeader\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ResponseValidatorTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldThrowExceptionIfResourceNotFound\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldThrowExceptionIfMethodNotFound\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldThrowExceptionIfResponseNotFound\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldThrowExceptionIfResponseBodyNotFound\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldCorrectlyReturnResponseBodyWithCompositeMediaType\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldThrowExceptionIfResponseBodyIsNotABodyObject\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldGetRequiredOrAllQueryParameters\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldGetRequestBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldGetResponse\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldGetResponseBody\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\Validator\\\\ValidatorSchemaHelperTest\\:\\:shouldGetResponseHeaders\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/Validator/ValidatorSchemaHelperTest.php
+
+		-
+			message: "#^Cannot call method getMethod\\(\\) on resource\\.$#"
+			count: 2
+			path: ../../../tests/XmlSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\XmlSchemaTest\\:\\:shouldReturnXmlSchemeDefinition\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/XmlSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\XmlSchemaTest\\:\\:shouldCorrectlyValidateCorrectXml\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/XmlSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\XmlSchemaTest\\:\\:shouldCorrectlyValidateIncorrectXml\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/XmlSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\XmlSchemaTest\\:\\:shouldConvertXmlToString\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/XmlSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\XmlSchemaTest\\:\\:shouldThrowExceptionOnIncorrectXml\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/XmlSchemaTest.php
+
+		-
+			message: "#^Method Raml\\\\Tests\\\\XmlSchemaTest\\:\\:assertValidationFailedWithErrors\\(\\) has no return typehint specified\\.$#"
+			count: 1
+			path: ../../../tests/XmlSchemaTest.php
+
+		-
+			message: "#^Method PHPUnit\\\\Framework\\\\Assert\\:\\:assertContainsEquals\\(\\) invoked with 5 parameters, 2\\-3 required\\.$#"
+			count: 1
+			path: ../../../tests/XmlSchemaTest.php
+
+		-
+			message: "#^Function assertValidationFailedWithErrors\\(\\) has an unused variable \\$message\\.$#"
+			count: 1
+			path: ../../../tests/XmlSchemaTest.php
+
+		-
+			message: "#^Function assertValidationFailedWithErrors\\(\\) has an unused variable \\$ignoreCase\\.$#"
+			count: 1
+			path: ../../../tests/XmlSchemaTest.php
+
+		-
+			message: "#^Function assertValidationFailedWithErrors\\(\\) has an unused variable \\$checkObjectIdentity\\.$#"
+			count: 1
+			path: ../../../tests/XmlSchemaTest.php
+

--- a/tools/phpstan/config.neon
+++ b/tools/phpstan/config.neon
@@ -1,0 +1,30 @@
+includes:
+	- %rootDir%/../../../vendor/phpstan/phpstan-phpunit/extension.neon
+	- %rootDir%/../../../tools/phpstan/baseline/src.neon
+	- %rootDir%/../../../tools/phpstan/baseline/tests.neon
+
+parameters:
+	level: 8
+	parallel:
+		processTimeout: 90.0
+	checkMissingIterableValueType: false
+	checkGenericClassInNonGenericObjectType: false
+	inferPrivatePropertyTypeFromConstructor: true
+
+services:
+    -
+        class: SlamPhpStan\GotoRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: SlamPhpStan\PhpUnitFqcnAnnotationRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: SlamPhpStan\StringToClassRule
+        tags:
+            - phpstan.rules.rule
+    -
+        class: SlamPhpStan\UnusedVariableRule
+        tags:
+            - phpstan.rules.rule

--- a/tools/phpunit/config.xml
+++ b/tools/phpunit/config.xml
@@ -12,18 +12,18 @@
     failOnRisky="true"
     beStrictAboutTestsThatDoNotTestAnything="true"
     beStrictAboutOutputDuringTests="true"
-    bootstrap="vendor/autoload.php"
+    bootstrap="../../vendor/autoload.php"
  >
 
     <testsuites>
         <testsuite name="PHP Raml Parser">
-            <directory>./tests</directory>
+            <directory>../../tests</directory>
         </testsuite>
     </testsuites>
 
     <filter>
         <whitelist>
-            <directory suffix=".php">./src</directory>
+            <directory suffix=".php">../../src</directory>
         </whitelist>
     </filter>
 


### PR DESCRIPTION
- Drop support for EOL PHP versions (< 7.3)
- Run Travis on PHP 7.4
- Update PHPStan to 0.12 and run analysis on level 8
- Update PHPUnit to 9
- Bundle CI tools configuration files under `tools/`