### PR TITLE
Add support for Symfony v6 components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "arthurkushman/raml-php-parser",
+  "name": "raml-org/raml-php-parser",
   "type": "library",
   "description": "A RAML parser built in php",
-  "homepage": "https://github.com/arthurkushman/raml-php-parser",
+  "homepage": "https://github.com/raml-org/raml-php-parser",
   "license": "MIT",
 
   "authors": [

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "ext-pcre": "*",
     "justinrainbow/json-schema": "^5.0",
     "symfony/yaml": "^3.0|^4.0|^5.0",
-    "symfony/routing": "^3.0|^4.0|^5.0",
+    "symfony/routing": "^3.0|^4.0|^5.0|^v6.0",
     "oodle/inflect": "^0.2",
     "psr/http-message": "^1.0",
     "willdurand/negotiation": "^2.2.1|^3"

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-  "name": "raml-org/raml-php-parser",
+  "name": "arthurkushman/raml-php-parser",
   "type": "library",
   "description": "A RAML parser built in php",
-  "homepage": "https://github.com/raml-org/raml-php-parser",
+  "homepage": "https://github.com/arthurkushman/raml-php-parser",
   "license": "MIT",
 
   "authors": [


### PR DESCRIPTION
Add `symfony/routing` - `^v6.0` to be able update/install laravel > 9 versions.
Solves #177 