### PR TITLE
Fix deprecation for PHP 8.1+

### DIFF
--- a/src/SecurityScheme/SecuritySettings/DefaultSecuritySettings.php
+++ b/src/SecurityScheme/SecuritySettings/DefaultSecuritySettings.php
@@ -70,7 +70,7 @@ class DefaultSecuritySettings implements SecuritySettingsInterface, \ArrayAccess
      *
      * @return bool
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->settings[$offset]);
     }
@@ -88,7 +88,7 @@ class DefaultSecuritySettings implements SecuritySettingsInterface, \ArrayAccess
      * Get a single settings value
      * @link http://php.net/manual/en/arrayaccess.offsetget.php
      */
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->settings[$offset] ?? null;
     }


### PR DESCRIPTION
When using PHP 8.1 or 8.2
- "PHP Deprecated:  Return type of Raml\SecurityScheme\SecuritySettings\DefaultSecuritySettings::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice"
- "PHP Deprecated:  Return type of Raml\SecurityScheme\SecuritySettings\DefaultSecuritySettings::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice"