### PR TITLE
ApiDefinition: Fix Deprecated warning on empty schema

### DIFF
--- a/src/ApiDefinition.php
+++ b/src/ApiDefinition.php
@@ -810,7 +810,7 @@ class ApiDefinition implements ArrayInstantiationInterface
 
     private function setProtocolsFromBaseUri(): void
     {
-        $schema = \mb_strtoupper(\parse_url($this->baseUri, PHP_URL_SCHEME));
+        $schema = \mb_strtoupper(\parse_url($this->baseUri, PHP_URL_SCHEME) ?? '');
 
         $this->protocols = empty($schema) ? [self::PROTOCOL_HTTPS, self::PROTOCOL_HTTP] : [$schema];
     }


### PR DESCRIPTION
According to line 815, empty schema is supported. This update avoid passing `null` when `$this->baseUri` doesn't have a scheme/schema from `\parse_url($this->baseUri, PHP_URL_SCHEME)` to `mb_strtoupper`.

Fix `PHP Deprecated:  mb_strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in /Users/adriendupuis/www/developer-documentation/tools/raml2html/vendor/raml-org/raml-php-parser/src/ApiDefinition.php on line 813`